### PR TITLE
feat(py): split BufferTree.update into update and update_batch

### DIFF
--- a/core/schiebung-core-py/src/lib.rs
+++ b/core/schiebung-core-py/src/lib.rs
@@ -422,18 +422,41 @@ impl BufferTree {
         }
     }
 
-    /// Insert one or more transforms into the buffer.
+    /// Insert a single transform into the buffer.
     ///
-    /// `updates` is a list of `(from, to, stamped_isometry, kind)` tuples. Pass
-    /// a single-element list to insert one transform; pass many to insert them
-    /// in a single bulk call. Observers (e.g. the rerun visualizer) are
-    /// notified once per call with the full batch, which lets columnar
-    /// observers send their data in one shot.
+    /// For inserting many transforms in one shot — and notifying observers
+    /// (e.g. the rerun visualizer) once per batch so columnar observers can
+    /// send their data in a single call — use [`update_batch`] instead.
+    pub fn update(
+        &mut self,
+        from: String,
+        to: String,
+        stamped_isometry: StampedIsometry,
+        kind: TransformType,
+    ) -> PyResult<()> {
+        let core_iso = CoreStampedIsometry::new(
+            stamped_isometry.translation(),
+            stamped_isometry.rotation(),
+            stamped_isometry.stamp(),
+        );
+        let core_update = CoreTransformUpdate::new(from, to, core_iso, kind.into());
+
+        self.inner
+            .update(&[core_update])
+            .map_err(core_err_to_pyerr)?;
+        Ok(())
+    }
+
+    /// Insert many transforms into the buffer in a single bulk call.
+    ///
+    /// `updates` is a list of `(from, to, stamped_isometry, kind)` tuples.
+    /// Observers are notified once per call with the full batch, which lets
+    /// columnar observers send their data in one shot.
     ///
     /// The call is fail-fast: if any tuple is rejected (cycle / multiple
     /// parents), the call returns an error and earlier tuples in the list
     /// remain applied.
-    pub fn update(
+    pub fn update_batch(
         &mut self,
         updates: Vec<(String, String, StampedIsometry, TransformType)>,
     ) -> PyResult<()> {
@@ -513,7 +536,8 @@ impl BufferTree {
 
     /// Register a Python callable as an observer.
     ///
-    /// The callable will be invoked once per transform inserted via `update`.
+    /// The callable will be invoked once per transform inserted via `update`
+    /// or `update_batch`.
     /// The callable signature should be: callback(from: str, to: str, transform: StampedIsometry, kind: TransformType) -> None
     ///
     /// When registered, the observer will immediately receive callbacks for all existing transforms in the buffer.

--- a/core/schiebung-core-py/tests/test_api.py
+++ b/core/schiebung-core-py/tests/test_api.py
@@ -28,7 +28,7 @@ def test_simple_lookup():
     t = StampedIsometry([1.0, 0.0, 0.0], [0.0, 0.0, 0.0, 1.0], 0.0)
 
     # Add a static transform from map to odom
-    buf.update([("map", "odom", t, TransformType.Static)])
+    buf.update("map", "odom", t, TransformType.Static)
 
     # Lookup latest
     res = buf.lookup_latest_transform("map", "odom")
@@ -43,7 +43,7 @@ def test_dynamic_lookup_interpolation():
     t1 = StampedIsometry([0.0, 0.0, 0.0], [0.0, 0.0, 0.0, 1.0], 0.0)
     t2 = StampedIsometry([10.0, 0.0, 0.0], [0.0, 0.0, 0.0, 1.0], 10.0)
 
-    buf.update([
+    buf.update_batch([
         ("odom", "base_link", t1, TransformType.Dynamic),
         ("odom", "base_link", t2, TransformType.Dynamic),
     ])
@@ -61,7 +61,7 @@ def test_lookup_exceptions():
 
     # Case 2: Graph disconnected
     t = StampedIsometry([0.0, 0.0, 0.0], [0.0, 0.0, 0.0, 1.0], 0.0)
-    buf.update([("A", "B", t, TransformType.Static)])
+    buf.update("A", "B", t, TransformType.Static)
     # Just lookup A->C
     with pytest.raises(ValueError, match="CouldNotFindTransform"):
          buf.lookup_transform("A", "C", 0.0)
@@ -70,7 +70,7 @@ def test_future_past_exceptions():
     buf = BufferTree()
     t1 = StampedIsometry([0.0, 0.0, 0.0], [0.0, 0.0, 0.0, 1.0], 10.0)
     t2 = StampedIsometry([0.0, 0.0, 0.0], [0.0, 0.0, 0.0, 1.0], 20.0)
-    buf.update([
+    buf.update_batch([
         ("A", "B", t1, TransformType.Dynamic),
         ("A", "B", t2, TransformType.Dynamic),
     ])
@@ -86,11 +86,11 @@ def test_cycle_detection():
     buf = BufferTree()
     t = StampedIsometry([0.0, 0.0, 0.0], [0.0, 0.0, 0.0, 1.0], 0.0)
 
-    buf.update([("A", "B", t, TransformType.Static)])
-    buf.update([("B", "C", t, TransformType.Static)])
+    buf.update("A", "B", t, TransformType.Static)
+    buf.update("B", "C", t, TransformType.Static)
 
     with pytest.raises(ValueError, match="InvalidGraph"):
-         buf.update([("C", "A", t, TransformType.Static)])
+         buf.update("C", "A", t, TransformType.Static)
 
 def test_urdf_loader_creation():
     """Test that UrdfLoader can be instantiated"""

--- a/core/schiebung-core-py/tests/test_observer.py
+++ b/core/schiebung-core-py/tests/test_observer.py
@@ -22,7 +22,7 @@ def test_python_observer_callback():
 
     # Add a transform - observer should be called
     t = StampedIsometry([1.0, 2.0, 3.0], [0.0, 0.0, 0.0, 1.0], 0.0)
-    buf.update([("world", "robot", t, TransformType.Static)])
+    buf.update("world", "robot", t, TransformType.Static)
 
     # Verify observer was called
     assert len(calls) == 1
@@ -39,7 +39,7 @@ def test_observer_receives_existing_transforms():
     # Add some transforms before registering observer
     t1 = StampedIsometry([1.0, 0.0, 0.0], [0.0, 0.0, 0.0, 1.0], 0.0)
     t2 = StampedIsometry([0.0, 2.0, 0.0], [0.0, 0.0, 0.0, 1.0], 1.0)
-    buf.update([
+    buf.update_batch([
         ("world", "link1", t1, TransformType.Static),
         ("link1", "link2", t2, TransformType.Dynamic),
     ])
@@ -79,7 +79,7 @@ def test_multiple_observers():
 
     # Add a transform
     t = StampedIsometry([1.0, 0.0, 0.0], [0.0, 0.0, 0.0, 1.0], 0.0)
-    buf.update([("a", "b", t, TransformType.Static)])
+    buf.update("a", "b", t, TransformType.Static)
 
     # Both observers should have been called
     assert len(calls1) == 1
@@ -113,7 +113,7 @@ def test_observer_with_class_method():
     buf.register_observer(obs)
 
     t = StampedIsometry([1.0, 0.0, 0.0], [0.0, 0.0, 0.0, 1.0], 0.0)
-    buf.update([("x", "y", t, TransformType.Dynamic)])
+    buf.update("x", "y", t, TransformType.Dynamic)
 
     assert len(obs.calls) == 1
     assert obs.calls[0] == ("x", "y")
@@ -132,4 +132,4 @@ def test_observer_exception_handling():
     # Adding a transform should not crash even though observer raises
     t = StampedIsometry([1.0, 0.0, 0.0], [0.0, 0.0, 0.0, 1.0], 0.0)
     # This should complete successfully
-    buf.update([("a", "b", t, TransformType.Static)])
+    buf.update("a", "b", t, TransformType.Static)

--- a/visualizer/schiebung-rerun-py/src/lib.rs
+++ b/visualizer/schiebung-rerun-py/src/lib.rs
@@ -39,9 +39,11 @@ impl RerunBufferTree {
     /// Example:
     ///     >>> from schiebung_rerun import RerunBufferTree, StampedIsometry, TransformType
     ///     >>> tree = RerunBufferTree("schiebung", "session_001", "stable_time", True)
-    ///     >>> # Access the buffer to add transforms (pass a list of updates)
+    ///     >>> # Access the buffer to add a single transform...
     ///     >>> t = StampedIsometry([1.0, 0.0, 0.0], [0.0, 0.0, 0.0, 1.0], 0)
-    ///     >>> tree.buffer.update([("world", "robot", t, TransformType.Static)])
+    ///     >>> tree.buffer.update("world", "robot", t, TransformType.Static)
+    ///     >>> # ...or many at once via update_batch
+    ///     >>> tree.buffer.update_batch([("world", "robot", t, TransformType.Static)])
     #[new]
     pub fn new(
         py: Python<'_>,
@@ -79,7 +81,7 @@ impl RerunBufferTree {
     /// Example:
     ///     >>> tree = RerunBufferTree("my_recording", "stable_time", True)
     ///     >>> buffer = tree.buffer
-    ///     >>> buffer.update([("world", "robot", transform, TransformType.Static)])
+    ///     >>> buffer.update("world", "robot", transform, TransformType.Static)
     ///     >>> result = buffer.lookup_latest_transform("world", "robot")
     #[getter]
     pub fn buffer(&self, py: Python<'_>) -> Py<BufferTree> {


### PR DESCRIPTION
## Summary
- Add a single-transform `BufferTree.update(from, to, stamped_isometry, kind)` to the Python bindings
- Rename the previous list-based form to `update_batch(updates)` so observers still get one notification per bulk insert
- Update Python tests and rerun-py docstrings to use the new API

Fixes #58

## Test plan
- [x] `cargo check --workspace`
- [x] `maturin develop --uv --release` for `schiebung-core-py` and `schiebung-rerun-py`
- [x] `pytest` in `core/schiebung-core-py` (38/38 passed)
- [x] `pytest` in `visualizer/schiebung-rerun-py` (3 passed, 3 pre-existing skips)

🤖 Generated with [Claude Code](https://claude.com/claude-code)