### PR TITLE
perf(rerun): collapse entity paths + accept ChunkBatcherConfig

### DIFF
--- a/core/schiebung-core-rs/src/types.rs
+++ b/core/schiebung-core-rs/src/types.rs
@@ -6,8 +6,9 @@ use std::fmt;
 ///
 /// This drives both how the buffer interpolates lookups and how the
 /// `schiebung-rerun` observer routes the transform onto entity paths
-/// (`transforms/...` for [`Dynamic`](TransformType::Dynamic),
-/// `static_transforms/...` for [`Static`](TransformType::Static)).
+/// (`tf` for [`Dynamic`](TransformType::Dynamic),
+/// `tf_static` for [`Static`](TransformType::Static), matching the ROS /
+/// rerun 0.32+ convention).
 #[derive(Clone, Copy, Debug)]
 pub enum TransformType {
     /// Changes over time. Each new sample is appended to the per-edge

--- a/visualizer/docs/rust.md
+++ b/visualizer/docs/rust.md
@@ -8,12 +8,13 @@ Rust library for visualizing Schiebung transforms using [Rerun](https://rerun.io
 
 This crate provides a `RerunObserver` that can be attached to a `BufferTree` to automatically log all transform updates to Rerun for visualization.
 
-Currently the logging of Transforms is rather simple:
+Transform logging is intentionally minimal and tuned for Rerun's batcher:
 
-* from is the parent frame
-* to is the child frame
-* All is under a flat namespace /transforms/{from}->{to}
-* We use the provided timeline to set the timestamp for each transform
+* Every buffer batch becomes at most two `send_columns` calls — one for dynamic transforms under the `tf` entity, one for static transforms under `tf_static` (matching the ROS / Rerun 0.32+ convention).
+* The parent/child relationship of each edge is carried in the `parent_frame` / `child_frame` data columns of Rerun's `Transform3D` archetype (named frames), not in the entity-path string, so the 3D viewer still builds the full transform graph from the collapsed paths.
+* Dynamic rows land on the user-supplied timeline at their original per-row stamps. Static rows are sent with no time index (Rerun-static semantics); the observer keeps an internal snapshot of every static frame ever seen and re-sends the full set on each static-touching update so deltas never wipe earlier statics from the collapsed entity.
+
+Trade-off vs. the older `transforms/{from}->{to}` layout: the entity panel no longer breaks transforms out per edge, but the 3D positioning is unchanged.
 
 ## Example
 

--- a/visualizer/schiebung-rerun-py/README.md
+++ b/visualizer/schiebung-rerun-py/README.md
@@ -33,6 +33,22 @@ re-exported from the [`schiebung`](https://pypi.org/project/schiebung/) package 
 they are the *same* types, so values pass freely between the two packages
 (`schiebung_rerun.StampedIsometry is schiebung.StampedIsometry`).
 
+### Tuning the recording stream
+
+`RerunBufferTree` / `RerunObserver` take an optional `batcher_config` — a
+[`rerun.ChunkBatcherConfig`](https://ref.rerun.io/docs/python/stable/common/initialization_functions/#rerun.ChunkBatcherConfig)
+(including its `DEFAULT` / `LOW_LATENCY` / `ALWAYS` / `NEVER` presets) controlling
+the chunk-batcher flush thresholds:
+
+```python
+import rerun as rr
+tree = RerunBufferTree("my_app", "recording_1", "stable_time", True,
+                       batcher_config=rr.ChunkBatcherConfig.LOW_LATENCY())
+```
+
+The `RERUN_FLUSH_TICK_SECS` / `RERUN_FLUSH_NUM_BYTES` / `RERUN_FLUSH_NUM_ROWS` /
+`RERUN_CHUNK_MAX_ROWS_IF_UNSORTED` environment variables still override it.
+
 ## Documentation
 
 Full documentation: [https://maximaerz.github.io/schiebung/](https://maximaerz.github.io/schiebung/) ·

--- a/visualizer/schiebung-rerun-py/src/lib.rs
+++ b/visualizer/schiebung-rerun-py/src/lib.rs
@@ -8,10 +8,17 @@
 //! `TfError`, `UrdfLoader`) are **re-exported from the `schiebung` package** —
 //! `schiebung_rerun.StampedIsometry is schiebung.StampedIsometry`, so values
 //! move freely between the two packages.
+//!
+//! Both constructors accept an optional `batcher_config` — a
+//! `rerun.ChunkBatcherConfig` (incl. its `DEFAULT` / `LOW_LATENCY` / `ALWAYS` /
+//! `NEVER` presets) — applied to the recording stream's chunk batcher.
+
+use std::time::Duration;
 
 use pyo3::basic::CompareOp;
 use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
+use rerun::log::ChunkBatcherConfig;
 use rerun::{RecordingStream, RecordingStreamBuilder};
 
 use schiebung::{
@@ -20,6 +27,38 @@ use schiebung::{
 };
 use schiebung_rerun::RerunObserver as CoreRerunObserver;
 
+/// Read a `rerun.ChunkBatcherConfig` (rerun-sdk's own pyclass, with its
+/// `DEFAULT` / `LOW_LATENCY` / `ALWAYS` / `NEVER` presets) duck-typed into the
+/// Rust [`ChunkBatcherConfig`] — we don't link the rerun extension module, so we
+/// just call its accessors.
+///
+/// Starts from the Rust default and overrides the four fields rerun's Python
+/// object exposes; `max_bytes_in_flight` (not exposed there) keeps its default.
+fn batcher_config_from_py(obj: &Bound<'_, PyAny>) -> PyResult<ChunkBatcherConfig> {
+    let mut config = ChunkBatcherConfig::default();
+
+    // `flush_tick` is a `datetime.timedelta`; go via `total_seconds()` so we
+    // don't depend on pyo3's timedelta conversion. The ALWAYS/NEVER presets set
+    // `flush_tick = Duration::MAX`, which rerun's Python side can't even render
+    // as a `timedelta` (it raises) — so on *any* failure here we fall back to
+    // `Duration::MAX`, i.e. "effectively never tick", which preserves the intent
+    // of those presets (and for ALWAYS the other thresholds force the flush
+    // anyway). If the object isn't a batcher config at all, the missing
+    // `flush_num_*` attrs below will surface a clear `AttributeError`.
+    match obj
+        .getattr("flush_tick")
+        .and_then(|t| t.call_method0("total_seconds")?.extract::<f64>())
+    {
+        Ok(secs) => config.flush_tick = Duration::try_from_secs_f64(secs).unwrap_or(Duration::MAX),
+        Err(_) => config.flush_tick = Duration::MAX,
+    }
+    config.flush_num_bytes = obj.getattr("flush_num_bytes")?.extract()?;
+    config.flush_num_rows = obj.getattr("flush_num_rows")?.extract()?;
+    config.chunk_max_rows_if_unsorted = obj.getattr("chunk_max_rows_if_unsorted")?.extract()?;
+
+    Ok(config)
+}
+
 /// Build a Rerun [`RecordingStream`] honoring the `spawn` / `connect_addr` knobs:
 ///
 /// * `connect_addr` set                       → connect to that gRPC endpoint
@@ -27,13 +66,19 @@ use schiebung_rerun::RerunObserver as CoreRerunObserver;
 /// * `connect_addr` `None`, `spawn` `true`    → spawn a viewer (the default).
 /// * `connect_addr` `None`, `spawn` `false`   → connect to a viewer already
 ///   running on the default gRPC port.
+///
+/// `batcher_config`, if given, is applied via [`RecordingStreamBuilder::batcher_config`].
 fn build_recording_stream(
     application_id: String,
     recording_id: String,
     spawn: bool,
     connect_addr: Option<String>,
+    batcher_config: Option<ChunkBatcherConfig>,
 ) -> PyResult<RecordingStream> {
-    let builder = RecordingStreamBuilder::new(application_id).recording_id(recording_id);
+    let mut builder = RecordingStreamBuilder::new(application_id).recording_id(recording_id);
+    if let Some(cfg) = batcher_config {
+        builder = builder.batcher_config(cfg);
+    }
     match connect_addr {
         Some(addr) => {
             let label = addr.clone();
@@ -104,8 +149,13 @@ impl RerunObserver {
     ///         default gRPC port.
     ///     connect_addr: If given, connect to this Rerun gRPC endpoint
     ///         (e.g. "rerun+http://127.0.0.1:9876/proxy"); overrides `spawn`.
+    ///     batcher_config: Optional `rerun.ChunkBatcherConfig` (e.g.
+    ///         `rr.ChunkBatcherConfig.LOW_LATENCY()`) controlling the recording
+    ///         stream's batch-flush thresholds. The `RERUN_FLUSH_TICK_SECS` /
+    ///         `RERUN_FLUSH_NUM_BYTES` / `RERUN_FLUSH_NUM_ROWS` /
+    ///         `RERUN_CHUNK_MAX_ROWS_IF_UNSORTED` env vars still override it.
     #[new]
-    #[pyo3(signature = (application_id, recording_id, timeline, publish_static_transforms, *, spawn=true, connect_addr=None))]
+    #[pyo3(signature = (application_id, recording_id, timeline, publish_static_transforms, *, spawn=true, connect_addr=None, batcher_config=None))]
     pub fn new(
         application_id: String,
         recording_id: String,
@@ -113,8 +163,18 @@ impl RerunObserver {
         publish_static_transforms: bool,
         spawn: bool,
         connect_addr: Option<String>,
+        batcher_config: Option<Bound<'_, PyAny>>,
     ) -> PyResult<Self> {
-        let rec = build_recording_stream(application_id, recording_id, spawn, connect_addr)?;
+        let batcher_config = batcher_config
+            .map(|c| batcher_config_from_py(&c))
+            .transpose()?;
+        let rec = build_recording_stream(
+            application_id,
+            recording_id,
+            spawn,
+            connect_addr,
+            batcher_config,
+        )?;
         Ok(RerunObserver {
             inner: CoreRerunObserver::new(rec, publish_static_transforms, timeline),
         })
@@ -168,9 +228,9 @@ impl RerunBufferTree {
     /// Create a `RerunBufferTree`.
     ///
     /// Takes the same arguments as [`RerunObserver`]; see there for the meaning
-    /// of `spawn` / `connect_addr`.
+    /// of `spawn` / `connect_addr` / `batcher_config`.
     #[new]
-    #[pyo3(signature = (application_id, recording_id, timeline, publish_static_transforms, *, spawn=true, connect_addr=None))]
+    #[pyo3(signature = (application_id, recording_id, timeline, publish_static_transforms, *, spawn=true, connect_addr=None, batcher_config=None))]
     pub fn new(
         py: Python<'_>,
         application_id: String,
@@ -179,6 +239,7 @@ impl RerunBufferTree {
         publish_static_transforms: bool,
         spawn: bool,
         connect_addr: Option<String>,
+        batcher_config: Option<Bound<'_, PyAny>>,
     ) -> PyResult<Self> {
         let observer = Py::new(
             py,
@@ -189,6 +250,7 @@ impl RerunBufferTree {
                 publish_static_transforms,
                 spawn,
                 connect_addr,
+                batcher_config,
             )?,
         )?;
         let buffer = py.import("schiebung")?.getattr("BufferTree")?.call0()?;

--- a/visualizer/schiebung-rerun-py/tests/test_rerun_buffer.py
+++ b/visualizer/schiebung-rerun-py/tests/test_rerun_buffer.py
@@ -1,6 +1,4 @@
 """Tests for schiebung_rerun Python bindings."""
-import os
-
 import pytest
 import rerun as rr
 
@@ -120,15 +118,3 @@ def test_batcher_config_rejects_non_config():
     with pytest.raises((AttributeError, TypeError)):
         RerunBufferTree("schiebung", "batcher", "stable_time", True,
                         connect_addr=DEAD_ADDR, batcher_config=object())
-
-
-@pytest.mark.skipif(os.environ.get("RERUN_TEST") != "1",
-                    reason="Spawns a Rerun viewer; set RERUN_TEST=1 to run")
-def test_rerun_buffer_tree_spawns_viewer():
-    """Smoke test the default code path that actually spawns a viewer."""
-    tree = RerunBufferTree("schiebung", "spawn_session", "stable_time", True)
-    tree.buffer.update(
-        "world", "robot",
-        StampedIsometry([1.0, 0.0, 0.0], [0.0, 0.0, 0.0, 1.0], 0),
-        TransformType.Static,
-    )

--- a/visualizer/schiebung-rerun-py/tests/test_rerun_buffer.py
+++ b/visualizer/schiebung-rerun-py/tests/test_rerun_buffer.py
@@ -2,7 +2,17 @@
 import os
 
 import pytest
-from schiebung_rerun import RerunBufferTree, StampedIsometry, TransformType, TfError, UrdfLoader
+import rerun as rr
+
+import schiebung
+from schiebung_rerun import (
+    RerunBufferTree,
+    RerunObserver,
+    StampedIsometry,
+    TransformType,
+    TfError,
+    UrdfLoader,
+)
 
 # A well-formed gRPC URL that nothing is listening on: the sink connects lazily
 # and drops data, so RerunBufferTree can be exercised without a viewer.
@@ -65,6 +75,51 @@ def test_rerun_buffer_tree_dynamic_interpolation():
     # Lookup at t=5s (5_000_000_000 ns) should give [5.0, 0.0, 0.0]
     result = tree.buffer.lookup_transform("odom", "base_link", 5_000_000_000)
     assert result.translation() == [5.0, 0.0, 0.0]
+
+
+def _roundtrip(tree):
+    """Push one transform through `tree.buffer` and read it back."""
+    tree.buffer.update(
+        "world", "robot",
+        StampedIsometry([1.0, 0.0, 0.0], [0.0, 0.0, 0.0, 1.0], 0),
+        TransformType.Static,
+    )
+    assert tree.buffer.lookup_latest_transform("world", "robot").translation() == [1.0, 0.0, 0.0]
+
+
+@pytest.mark.parametrize(
+    "cfg",
+    [
+        None,
+        rr.ChunkBatcherConfig.LOW_LATENCY(),                       # non-trivial flush_tick (8ms)
+        rr.ChunkBatcherConfig.ALWAYS(),                            # flush_tick == Duration::MAX path
+        rr.ChunkBatcherConfig(flush_num_rows=1, flush_num_bytes=1),
+    ],
+)
+def test_batcher_config_accepted(cfg):
+    """RerunBufferTree accepts a rerun.ChunkBatcherConfig (incl. presets) and still works."""
+    tree = RerunBufferTree("schiebung", "batcher", "stable_time", True,
+                           connect_addr=DEAD_ADDR, batcher_config=cfg)
+    _roundtrip(tree)
+
+
+def test_batcher_config_on_observer():
+    """RerunObserver also accepts batcher_config."""
+    buf = schiebung.BufferTree()
+    buf.register_observer(RerunObserver("schiebung", "batcher", "stable_time", True,
+                                        connect_addr=DEAD_ADDR,
+                                        batcher_config=rr.ChunkBatcherConfig.LOW_LATENCY()))
+    buf.update("world", "robot",
+               StampedIsometry([1.0, 0.0, 0.0], [0.0, 0.0, 0.0, 1.0], 0),
+               TransformType.Static)
+    assert buf.lookup_latest_transform("world", "robot").translation() == [1.0, 0.0, 0.0]
+
+
+def test_batcher_config_rejects_non_config():
+    """Passing something that isn't a batcher config raises a clear error."""
+    with pytest.raises((AttributeError, TypeError)):
+        RerunBufferTree("schiebung", "batcher", "stable_time", True,
+                        connect_addr=DEAD_ADDR, batcher_config=object())
 
 
 @pytest.mark.skipif(os.environ.get("RERUN_TEST") != "1",

--- a/visualizer/schiebung-rerun-rs/README.md
+++ b/visualizer/schiebung-rerun-rs/README.md
@@ -2,7 +2,7 @@
 
 [Rerun](https://rerun.io) visualization adapter for the [`schiebung`](https://crates.io/crates/schiebung) transform buffer.
 
-`RerunObserver` implements `BufferObserver` and bulk-logs every batched buffer update to a Rerun recording stream via the columnar `send_columns` API — one call per entity path per batch — so a full transform-graph snapshot (e.g. a multi-sensor rig or a robot pose) becomes a single bulk write rather than N row-oriented logs.
+`RerunObserver` implements `BufferObserver` and bulk-logs every batched buffer update to a Rerun recording stream via the columnar `send_columns` API. All dynamic transforms land on a single `tf` entity and all static transforms on a single `tf_static` entity (ROS / Rerun 0.32+ convention) — so a full transform-graph snapshot (e.g. a multi-sensor rig or a robot pose) becomes at most two columnar writes per batch rather than N row-oriented logs. The parent/child relationship of each edge is carried as named-frames data on the `Transform3D` archetype, so collapsing the entity paths does not change the transform graph the 3D viewer builds.
 
 - **Documentation:** <https://maximaerz.github.io/schiebung/>
 - **Repository:** <https://github.com/MaxiMaerz/schiebung>

--- a/visualizer/schiebung-rerun-rs/examples/demo.rs
+++ b/visualizer/schiebung-rerun-rs/examples/demo.rs
@@ -49,6 +49,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     for i in 0..num_steps {
         let time = i as f64 * 0.01;
+        rec.set_timestamp_secs_since_epoch("stable_time", time);
         let earth_angle = (time / earth_period) * 2.0 * std::f64::consts::PI;
         let earth_x = earth_orbit_radius * earth_angle.cos();
         let earth_y = earth_orbit_radius * earth_angle.sin();

--- a/visualizer/schiebung-rerun-rs/examples/urdf_demo.rs
+++ b/visualizer/schiebung-rerun-rs/examples/urdf_demo.rs
@@ -1,8 +1,6 @@
 use nalgebra::UnitQuaternion;
 use rerun::RecordingStreamBuilder;
-use schiebung::{
-    BufferTree, FormatLoader, StampedIsometry, TransformType, TransformUpdate, UrdfLoader,
-};
+use schiebung::{BufferTree, StampedIsometry, TransformType, TransformUpdate};
 use schiebung_rerun::RerunObserver;
 use std::env;
 use std::path::PathBuf;
@@ -22,35 +20,35 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let mut buffer = BufferTree::new();
 
-    let loader = UrdfLoader::new();
-    loader.load_into_buffer(urdf_path.to_str().unwrap(), &mut buffer)?;
-
-    let observer = RerunObserver::new(rec.clone(), false, "stable_time".to_string());
+    // publish_static_transforms = true so the cube static below is logged
+    // through the observer on `tf_static`. The URDF's own fixed joints are
+    // NOT loaded into the buffer (no `UrdfLoader::load_into_buffer` call)
+    // because `rec.log_file_from_path` already populates rerun's transform
+    // tree for them; routing them through the observer too would double-log.
+    let observer = RerunObserver::new(rec.clone(), true, "stable_time".to_string());
     buffer.register_observer(Box::new(observer));
 
     rec.log_file_from_path(urdf_path.to_str().unwrap(), None, true)?;
 
     // Place a small static cube in the robot's workspace so we can visualize
-    // the distance from the wrist tip to it as the arm moves. Insert the
-    // transform into the buffer so we can query it, and log the visual +
-    // transform directly to rerun (the observer skips static transforms here
-    // because the URDF loader has already populated rerun's transform tree).
+    // the distance from the wrist tip to it as the arm moves. Inserting it as
+    // Static into the buffer makes the observer publish `base_link ->
+    // target_cube` on the collapsed `tf_static` entity (named-frames graph),
+    // registering `target_cube` as a frame at this pose. The box visual below
+    // opts into that frame via `with_parent_frame`.
     let cube_pose = StampedIsometry::from_secs([0.6, 0.4, 1.0], [0.0, 0.0, 0.0, 1.0], 0.0);
     buffer.update(&[TransformUpdate::new(
         "base_link",
         "target_cube",
-        cube_pose.clone(),
+        cube_pose,
         TransformType::Static,
     )])?;
 
     rec.log_static(
         "target_cube",
         &[
-            &rerun::Transform3D::from_translation(cube_pose.translation().map(|v| v as f32))
-                .with_quaternion(rerun::Quaternion::from_xyzw(
-                    cube_pose.rotation().map(|v| v as f32),
-                ))
-                .with_parent_frame("base_link".to_string()) as &dyn rerun::AsComponents,
+            &rerun::Transform3D::default().with_parent_frame("target_cube".to_string())
+                as &dyn rerun::AsComponents,
             &rerun::Boxes3D::from_half_sizes([[0.05, 0.05, 0.05]])
                 .with_colors([rerun::Color::from_rgb(220, 60, 60)])
                 .with_fill_mode(rerun::FillMode::Solid),

--- a/visualizer/schiebung-rerun-rs/src/lib.rs
+++ b/visualizer/schiebung-rerun-rs/src/lib.rs
@@ -2,17 +2,36 @@
 #![warn(missing_docs)]
 
 use std::collections::HashMap;
+use std::sync::Mutex;
 
 use rerun::{RecordingStream, TimeColumn};
 use schiebung::{BufferObserver, TransformType, TransformUpdate};
 
+/// Entity path that carries every dynamic transform. Matches ROS / rerun
+/// 0.32+ convention.
+const DYNAMIC_ENTITY_PATH: &str = "tf";
+/// Entity path that carries every static transform. Matches ROS / rerun
+/// 0.32+ convention.
+const STATIC_ENTITY_PATH: &str = "tf_static";
+
 /// Observer that logs transforms to a Rerun recording stream.
 ///
-/// Each `on_update` call from the buffer becomes one or more `send_columns`
-/// calls into rerun — one per distinct entity path in the batch — using
-/// rerun's columnar bulk-write API. Static and dynamic transforms live on
-/// separate entity-path namespaces (`static_transforms/{to}` and
-/// `transforms/{from}->{to}`) so they never end up in the same group.
+/// Every `on_update` call from the buffer turns into at most two
+/// `send_columns` calls: one columnar batch of all dynamic rows under
+/// [`DYNAMIC_ENTITY_PATH`] (`"tf"`) on the configured timeline, and one
+/// batch of all static rows under [`STATIC_ENTITY_PATH`] (`"tf_static"`)
+/// with no time index. The parent/child relationship
+/// of each edge is carried in the `parent_frame` / `child_frame` data columns
+/// of rerun's `Transform3D` archetype (named frames) rather than in the
+/// entity-path string, so collapsing to two fixed paths does not change the
+/// transform graph rerun builds for the 3D view — only the entity-panel
+/// tree no longer breaks transforms out per edge.
+///
+/// Static transforms use rerun's static-logging semantics ("latest write
+/// wins per entity"), so the observer keeps an internal snapshot of every
+/// static frame it has ever seen and re-sends the full set whenever any
+/// static-touching batch arrives. Otherwise a delta with one new static
+/// would overwrite all previously logged statics on the collapsed entity.
 ///
 /// If the model (e.g. a URDF) is loaded via rerun the `publish_static_transforms`
 /// flag should be set to false; otherwise the static transforms will be logged
@@ -41,6 +60,10 @@ pub struct RerunObserver {
     rec: RecordingStream,
     publish_static_transforms: bool,
     timeline: String,
+    /// Every static transform ever seen, keyed by (parent, child). Re-sent
+    /// in full on every static-touching `on_update` because rerun-static
+    /// replaces all component values on the entity on each write.
+    static_state: Mutex<HashMap<(String, String), Row>>,
 }
 
 impl RerunObserver {
@@ -62,26 +85,30 @@ impl RerunObserver {
             rec,
             publish_static_transforms,
             timeline,
+            static_state: Mutex::new(HashMap::new()),
         }
     }
 }
 
-/// Single row of columnar data we collect per entity path before sending.
-struct Row<'a> {
-    parent: &'a str,
-    child: &'a str,
+/// Single row of columnar data we collect before sending. Strings are owned
+/// so rows can be cached in the static-state snapshot across `on_update`
+/// calls.
+#[derive(Clone)]
+struct Row {
+    parent: String,
+    child: String,
     translation: [f32; 3],
     quaternion: [f32; 4],
     /// Stamp in nanoseconds since unix epoch. Unused for static entries.
     stamp_ns: i64,
 }
 
-fn row_from(update: &TransformUpdate) -> Row<'_> {
+fn row_from(update: &TransformUpdate) -> Row {
     let t = update.stamped_isometry.translation();
     let r = update.stamped_isometry.rotation();
     Row {
-        parent: &update.from,
-        child: &update.to,
+        parent: update.from.clone(),
+        child: update.to.clone(),
         translation: [t[0] as f32, t[1] as f32, t[2] as f32],
         quaternion: [r[0] as f32, r[1] as f32, r[2] as f32, r[3] as f32],
         stamp_ns: update.stamped_isometry.stamp(),
@@ -90,39 +117,41 @@ fn row_from(update: &TransformUpdate) -> Row<'_> {
 
 impl BufferObserver for RerunObserver {
     fn on_update(&self, updates: &[TransformUpdate]) {
-        // Partition updates by entity path. Dynamic and static use separate
-        // path prefixes so a single (kind, entity_path) key isn't necessary.
-        let mut dynamic_groups: HashMap<String, Vec<Row<'_>>> = HashMap::new();
-        let mut static_groups: HashMap<String, Vec<Row<'_>>> = HashMap::new();
+        let mut dynamic_rows: Vec<Row> = Vec::new();
+        let mut static_updates: Vec<Row> = Vec::new();
 
         for update in updates {
-            let row = row_from(update);
             match update.kind {
-                TransformType::Dynamic => {
-                    let path = format!("transforms/{}->{}", row.parent, row.child);
-                    dynamic_groups.entry(path).or_default().push(row);
-                }
+                TransformType::Dynamic => dynamic_rows.push(row_from(update)),
                 TransformType::Static => {
-                    if !self.publish_static_transforms {
-                        continue;
+                    if self.publish_static_transforms {
+                        static_updates.push(row_from(update));
                     }
-                    let path = format!("static_transforms/{}", row.child);
-                    static_groups.entry(path).or_default().push(row);
                 }
             }
         }
 
-        for (entity_path, rows) in dynamic_groups {
-            self.send_dynamic(&entity_path, &rows);
+        if !dynamic_rows.is_empty() {
+            self.send_dynamic(DYNAMIC_ENTITY_PATH, &dynamic_rows);
         }
-        for (entity_path, rows) in static_groups {
-            self.send_static(&entity_path, &rows);
+
+        if !static_updates.is_empty() {
+            // Merge deltas into state and snapshot under a single lock, then
+            // release before calling rerun so the batcher never blocks on us.
+            let snapshot: Vec<Row> = {
+                let mut state = self.static_state.lock().unwrap();
+                for row in static_updates {
+                    state.insert((row.parent.clone(), row.child.clone()), row);
+                }
+                state.values().cloned().collect()
+            };
+            self.send_static(STATIC_ENTITY_PATH, &snapshot);
         }
     }
 }
 
 impl RerunObserver {
-    fn send_dynamic(&self, entity_path: &str, rows: &[Row<'_>]) {
+    fn send_dynamic(&self, entity_path: &str, rows: &[Row]) {
         let stamps: Vec<i64> = rows.iter().map(|r| r.stamp_ns).collect();
         let time_column =
             TimeColumn::new_timestamp_nanos_since_epoch(self.timeline.as_str(), stamps);
@@ -138,7 +167,7 @@ impl RerunObserver {
         }
     }
 
-    fn send_static(&self, entity_path: &str, rows: &[Row<'_>]) {
+    fn send_static(&self, entity_path: &str, rows: &[Row]) {
         // Static transforms have no time index — pass an empty timeline list.
         if let Some((tf_columns, frame_columns)) = build_columns(rows) {
             self.rec
@@ -152,12 +181,12 @@ impl RerunObserver {
     }
 }
 
-/// Build the Transform3D and CoordinateFrame component columns for one
-/// entity-path group. Returns `None` if rerun's columnar serialization fails
-/// for either archetype (logged via `re_log` inside rerun).
+/// Build the Transform3D and CoordinateFrame component columns for a batch
+/// of rows. Returns `None` if rerun's columnar serialization fails for
+/// either archetype (logged via `re_log` inside rerun).
 #[allow(clippy::type_complexity)]
 fn build_columns(
-    rows: &[Row<'_>],
+    rows: &[Row],
 ) -> Option<(
     impl Iterator<Item = rerun::SerializedComponentColumn>,
     impl Iterator<Item = rerun::SerializedComponentColumn>,
@@ -167,8 +196,8 @@ fn build_columns(
         .iter()
         .map(|r| rerun::Quaternion::from_xyzw(r.quaternion))
         .collect();
-    let parents: Vec<String> = rows.iter().map(|r| r.parent.to_owned()).collect();
-    let children: Vec<String> = rows.iter().map(|r| r.child.to_owned()).collect();
+    let parents: Vec<String> = rows.iter().map(|r| r.parent.clone()).collect();
+    let children: Vec<String> = rows.iter().map(|r| r.child.clone()).collect();
 
     let tf_columns = rerun::archetypes::Transform3D::update_fields()
         .with_many_translation(translations)


### PR DESCRIPTION
## Summary

Two related changes that let the `schiebung-rerun` observer actually exploit rerun's chunk batcher.

### 1. Collapse entity paths to `tf` / `tf_static`

Previously each `(parent, child)` edge produced its own `transforms/{from}->{to}` or `static_transforms/{child}` entity path, so a batch with N edges fanned out into N `send_columns` calls — defeating the batcher. Now every `on_update` produces at most two columnar writes regardless of edge count, on the fixed paths `tf` (dynamic) and `tf_static` (static), matching the ROS / rerun 0.32+ convention.

The transform graph still resolves correctly because the parent/child relationship is carried in `Transform3D`'s named-frames data columns (`parent_frame` / `child_frame`), not in the entity-path string. Only the entity-panel tree loses its per-edge breakdown — the 3D positioning is unchanged.

**Static-transform subtlety**: rerun-static replaces *all* component values on the entity on every write, so a delta on the collapsed `tf_static` path would wipe previously logged statics. The observer now keeps a `Mutex<HashMap<(String, String), Row>>` of every static ever seen and re-sends the full snapshot whenever any static-touching batch arrives — correct under incremental statics, not just the URDF-at-startup case.

### 2. Accept `rerun.ChunkBatcherConfig` on the Python bindings

`schiebung_rerun` builds its own Rerun `RecordingStream` in Rust (it's not the rerun-sdk global recording), so none of rerun-sdk's Python knobs reach it — the only stream knobs surfaced were `spawn` / `connect_addr`.

This adds an optional keyword-only `batcher_config` to both `RerunObserver.__init__` and `RerunBufferTree.__init__` that accepts `rr.ChunkBatcherConfig` (including its `DEFAULT` / `LOW_LATENCY` / `ALWAYS` / `NEVER` presets). Fields are read duck-typed in Rust and applied via `RecordingStreamBuilder::batcher_config`.

```python
import rerun as rr
from schiebung_rerun import RerunBufferTree

tree = RerunBufferTree("my_app", "rec", "stable_time", True,
                       batcher_config=rr.ChunkBatcherConfig.LOW_LATENCY())
```

Notes:
- `flush_tick` is a `datetime.timedelta` on the Python side; read via `total_seconds()`. The `ALWAYS` / `NEVER` presets use `Duration::MAX`, which rerun's Python side can't even render as a `timedelta` — any failure reading `flush_tick` falls back to `Duration::MAX` to preserve intent.
- `max_bytes_in_flight` is not exposed by rerun's Python config, so it keeps the Rust default.
- `RERUN_FLUSH_TICK_SECS` / `RERUN_FLUSH_NUM_BYTES` / `RERUN_FLUSH_NUM_ROWS` / `RERUN_CHUNK_MAX_ROWS_IF_UNSORTED` env vars still override everything.
- Passing a non-config object surfaces a clear `AttributeError`.
- Backward compatible — new optional kwarg; positional args unchanged.

## Incidentals

- `urdf_demo`: drop `UrdfLoader::load_into_buffer` so the observer doesn't double-log the URDF's own static joints; enable `publish_static_transforms` and route the red cube through `tf_static` end-to-end as a worked example.
- `demo`: `set_timestamp_secs_since_epoch` was set only once before the loop, so `rec.log("Moon/distance", ...)` inside the loop was stuck at `t=0` and the distance arrow never moved. Latent bug — became visible once the viewer started correctly anchoring entities to named frames. Bumped each iteration.
- Drop the interactive `test_rerun_buffer_tree_spawns_viewer` — it was a viewer-side eyeball check, not an assertion.
- Refresh `visualizer/docs/rust.md` and the `schiebung-rerun-rs` README to describe the new layout, the named-frames mechanism, and the static-snapshot behavior.

## Test plan

- [x] `cargo test --workspace` — clean
- [x] `cargo build -p schiebung-rerun -p schiebung-rerun-py` — clean
- [x] `maturin develop && pytest` in `visualizer/schiebung-rerun-py` — 20/20 (parametrized batcher-config tests cover `None` / `LOW_LATENCY` / `ALWAYS` / custom `ChunkBatcherConfig(flush_num_rows=1, flush_num_bytes=1)` plus a `pytest.raises` for non-config objects)
- [x] `cargo run --example demo -p schiebung-rerun` — Sun/Earth/Moon animate; distance arrow tracks Moon→Sun direction
- [x] `cargo run --example urdf_demo -p schiebung-rerun -- resources/test_robot.urdf` — arm animates; entity panel shows `tf` (dynamic joints) and `tf_static` (red cube via named frames); wrist→cube arrow tracks the cube

🤖 Generated with [Claude Code](https://claude.com/claude-code)