### PR TITLE
ci(release): drop stray package axis from musllinux-core matrix

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -60,11 +60,6 @@ jobs:
     strategy:
       matrix:
         target: [x86_64, aarch64]
-        package:
-          - name: schiebung-core-py
-            path: core/schiebung-core-py
-          - name: schiebung-rerun-py
-            path: visualizer/schiebung-rerun-py
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5


### PR DESCRIPTION
The `package` matrix axis was never wired into the steps — the maturin invocation and upload-artifact name both hardcoded `schiebung-core-py`. The 2×2 matrix therefore ran the same build four times and two cells per target collided on the artifact name with a 409 Conflict.

Per the comment block at the top of the workflow, schiebung-rerun-py is intentionally not built for musllinux (rerun-sdk ships no musllinux wheels). Dropping the package axis brings the job in line with that.